### PR TITLE
Add Unit Tests for CpuMetricsService

### DIFF
--- a/aws/ecs/tests/conftest.py
+++ b/aws/ecs/tests/conftest.py
@@ -3,20 +3,24 @@ Global fixtures for tests
 Author: Tom Aston
 """
 
+import time
+import uuid
+from typing import Generator
+
 import pytest
 from fastapi.testclient import TestClient
-from src.cpu_metrics.schemas import CpuMetricCreateSchema
+from src.cpu_metrics.schemas import CpuMetricCreateSchema, CpuMetricSchema
 from src.main import app
 
 
 @pytest.fixture
-def test_client() -> TestClient:
+def test_client() -> Generator[TestClient, None, None]:
     """test client fixture
 
     Returns:
         TestClient: test client
     """
-    return TestClient(app)
+    yield TestClient(app)
 
 
 @pytest.fixture
@@ -58,3 +62,57 @@ def test_create_payload() -> list[CpuMetricCreateSchema]:
             version="1.0",
         ),
     ]
+
+
+@pytest.fixture
+def test_cpu_metrics_response_json() -> CpuMetricSchema:
+    """test repspone to get all cpu metrics
+
+    Returns:
+        List[CpuMetricSchema]: dummy json payload
+    """
+    return [
+        CpuMetricSchema(
+            location="Home",
+            cpu_usage=10,
+            unit="percent",
+            loop_count=1,
+            project="test",
+            topic="test",
+            device="test",
+            version="1.0",
+            id=str(uuid.uuid4()),
+            timestamp=int(time.time()),
+        ),
+        CpuMetricSchema(
+            location="Office",
+            cpu_usage=20,
+            unit="percent",
+            loop_count=1,
+            project="test",
+            topic="test",
+            device="test",
+            version="1.0",
+            id=str(uuid.uuid4()),
+            timestamp=int(time.time()),
+        ),
+        CpuMetricSchema(
+            location="Factory",
+            cpu_usage=30,
+            unit="percent",
+            loop_count=1,
+            project="test",
+            topic="test",
+            device="test",
+            version="1.0",
+            id=str(uuid.uuid4()),
+            timestamp=int(time.time()),
+        ),
+    ]
+
+
+def mock_client() -> TestClient:
+    """
+    Test client
+    """
+    return TestClient(app)

--- a/aws/ecs/tests/cpu_metrics/test_routes.py
+++ b/aws/ecs/tests/cpu_metrics/test_routes.py
@@ -3,14 +3,14 @@ Unit tests for the routes module
 Author: Tom Aston
 """
 
+from src.config import config_manager
 
-class TestSuiteCpuMetricRoutes:
+API_VERSION = config_manager.VERSION
+
+
+class TestUnitCpuMetricRoutes:
     """
     Test suite for the routes module in CPU Metrics API
     """
 
-    def test_get_all_cpu_metrics(self):
-        """
-        Test get all cpu metrics
-        """
-        assert True
+    pass

--- a/aws/ecs/tests/cpu_metrics/test_service.py
+++ b/aws/ecs/tests/cpu_metrics/test_service.py
@@ -2,3 +2,114 @@
 Unit tests for the service module.
 Author: Tom Aston
 """
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from src.cpu_metrics.schemas import CpuMetricCreateSchema, CpuMetricQueryParams
+from src.cpu_metrics.service import CpuMetricsService
+
+
+class TestUnitCpuMetricsService:
+    """
+    Unit tests for the service module in CPU Metrics API
+    """
+
+    @pytest.fixture
+    def mock_db_table(self) -> Mock:
+        """mock db table fixture
+
+        Returns:
+            Mock: mock of db table
+        """        
+        return Mock()
+
+    @pytest.mark.parametrize(
+        "query_params",
+        [
+            CpuMetricQueryParams(),
+            CpuMetricQueryParams(location_value="Home", operator="gt", cpu_usage_value=0),
+            CpuMetricQueryParams(location_value="*", operator="gt", cpu_usage_value=0),
+        ],
+    )
+    def test_get_all_cpu_metrics(self, query_params: CpuMetricQueryParams, mock_db_table: Mock) -> None:
+        """test filter cpu metrics logic
+
+        Args:
+            mock_db_table (Mock): db table mock
+        """
+        cpu_metrics_service = CpuMetricsService()
+
+        # mock the protected methods
+        cpu_metrics_service._get_all_cpu_metrics = Mock()
+        cpu_metrics_service._get_filtered_cpu_metrics = Mock()
+        cpu_metrics_service._get_all_devices_filtered_by_cpu_usage = Mock()
+
+        # call the get cpu metrics method
+        cpu_metrics_service.get_cpu_metrics(cpu_metric_table=mock_db_table, params=query_params)
+
+        if query_params.location_value and query_params.operator and query_params.cpu_usage_value is not None:
+            cpu_metrics_service._get_filtered_cpu_metrics.assert_called_once_with(mock_db_table, params=query_params)
+        else:
+            cpu_metrics_service._get_all_cpu_metrics.assert_called_once_with(mock_db_table)
+
+    def test_get_all_cpu_metrics_with_location_wildcard(self, mock_db_table: Mock) -> None:
+        """test get all cpu metrics with location wildcard
+
+        Args:
+            mock_db_table (Mock): db table mock
+        """
+        cpu_metrics_service = CpuMetricsService()
+
+        # mock the protected methods
+        cpu_metrics_service._get_all_devices_filtered_by_cpu_usage = Mock()
+
+        query_params = CpuMetricQueryParams(location_value="*", operator="gt", cpu_usage_value=0)
+
+        # call the get cpu metrics method
+        cpu_metrics_service.get_cpu_metrics(cpu_metric_table=mock_db_table, params=query_params)
+
+        cpu_metrics_service._get_all_devices_filtered_by_cpu_usage.assert_called_once_with(
+            mock_db_table, query_params.cpu_usage_value, query_params.operator
+        )
+
+    def test_create_cpu_metric(self, mock_db_table: Mock, test_create_payload: list[CpuMetricCreateSchema]) -> None:
+        """test create cpu metric. make sure the put_item method is called and the response has an id and timestamp
+
+        Args:
+            mock_db_table (Mock): mock of db table
+            test_create_payload (list[CpuMetricCreateSchema]): payload to create cpu metric from conftest.py
+        """
+        mock_db_table.put_item = Mock()
+
+        single_create_payload = test_create_payload[0]
+
+        cpu_metrics_service = CpuMetricsService()
+
+        single_create_payload = test_create_payload[0]
+        response = cpu_metrics_service.create_cpu_metric(
+            cpu_metric_table=mock_db_table, cpu_metric=single_create_payload
+        )
+
+        mock_db_table.put_item.assert_called_once()
+        assert response["timestamp"] is not None
+        assert response["id"] is not None
+
+    def test_batch_create_cpu_metrics(self, test_create_payload: list[CpuMetricCreateSchema]) -> None:
+        """test batch create cpu metrics
+
+        Args:
+            mock_db_table (Mock): mock of db table
+            test_create_payload (list[CpuMetricCreateSchema]): payload to create cpu metric from conftest.py
+        """
+        mock_db_table = MagicMock()
+        cpu_metrics_service = CpuMetricsService()
+
+        response = cpu_metrics_service.batch_create_cpu_metrics(
+            cpu_metric_table=mock_db_table, cpu_metrics=test_create_payload
+        )
+
+        assert len(response) == len(test_create_payload)
+        for item in response:
+            assert item["timestamp"] is not None
+            assert item["id"] is not None


### PR DESCRIPTION
###  📌 Description:
This PR adds unit tests for the `CpuMetricsService` in the **CPU Metrics API**, ensuring key functionalities are correctly implemented and tested. The tests cover different query scenarios, metric creation, and batch creation logic.

### 🔍 Changes Included:
- Added unit tests for get_cpu_metrics, covering different filtering logic.
- Implemented tests for handling wildcard location values.
- Added tests for create_cpu_metric, ensuring correct database interactions.
- Included tests for batch_create_cpu_metrics, verifying bulk creation behavior.
- Used Mock and MagicMock for database table interactions.

### ✅ Testing Strategy:

- Used pytest for unit testing.
- Parameterized tests to validate various input scenarios.
- Mocked protected methods to ensure isolated testing of logic.
- Verified expected function calls and return values.

### 🚀 How to Test:
Run the test suite with: `pytest tests/cpu_metrics`
